### PR TITLE
Support multiple K8s contexts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   capture-kubeconfig:
     image: ${DESKTOP_PLUGIN_IMAGE}
+    network_mode: "host"
     volumes:
       - kubeconfig:/root/.kube:rw
     healthcheck:
@@ -16,10 +17,13 @@ services:
     # Source: https://github.com/spurin/container-k9s-ttyd-kubectl
     # Container: https://hub.docker.com/r/spurin/k9s-ttyd-kubectl
     image: spurin/k9s-ttyd-kubectl
+    command: [ "/bin/ttyd", "-p", "35781", "sh",  "-c", "'/bin/k9s; exit 1'" ]
+    network_mode: "host"
     volumes:
       - kubeconfig:/kubeconfig
-    ports:
-      - 35781:7681
+#    ports:
+#      - "0.0.0.0:35781:35781"
+#      - 35781:7681
     depends_on:
       capture-kubeconfig:
         condition: service_healthy

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@loftsh/vcluster-dd-extension",
+  "name": "@spurin/k9s-dd-extension",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@loftsh/vcluster-dd-extension",
+      "name": "@spurin/k9s-dd-extension",
       "version": "0.0.1",
       "dependencies": {
         "@docker/docker-mui-theme": "^0.0.7",

--- a/ui/src/helper/cli.ts
+++ b/ui/src/helper/cli.ts
@@ -15,12 +15,12 @@ const storeValuesFileInContainer = async (ddClient: v1.DockerDesktopClient, valu
     return ddClient.extension.vm?.service?.post("/store-values", {data: values});
 }
 
-// Gets docker-desktop kubeconfig file from local and save it in container's /root/.kube/config file-system.
+// Gets the kubeconfig file from local and save it in container's /root/.kube/config file-system.
 // We have to use the vm.service to call the post api to store the kubeconfig retrieved. Without post api in vm.service
 // all the combinations of commands fail
 export const updateDockerDesktopK8sKubeConfig = async (ddClient: v1.DockerDesktopClient) => {
     // kubectl config view --raw
-    let kubeConfig = await hostCli(ddClient, "kubectl", ["config", "view", "--raw", "--minify", "--context", DockerDesktop]);
+    let kubeConfig = await hostCli(ddClient, "kubectl", ["config", "view", "--raw", "--minify"]);
     if (kubeConfig?.stderr) {
         console.log("error", kubeConfig?.stderr);
         return false;
@@ -70,5 +70,5 @@ export const getContainerK8sContext = async (ddClient: v1.DockerDesktopClient) =
 // Retrieves kubectl cluster-info
 export const checkK8sConnection = async (ddClient: v1.DockerDesktopClient) => {
     // kubectl cluster-info
-    return await cli(ddClient, "kubectl", ["cluster-info"]);
+    return await cli(ddClient, "kubectl", ["--kubeconfig=/root/.kube/config", "cluster-info"]);
 }


### PR DESCRIPTION
Some developers may create Kubernetes clusters differently, like using `kind`, e.g.:

`kind create cluster`

That will spin up a a container running in a random port:

```
CONTAINER ID   IMAGE                                      COMMAND                  CREATED         STATUS                   PORTS                       NAMES
060dd9cc63bc   kindest/node:v1.21.1                       "/usr/local/bin/entr…"   2 hours ago     Up 9 minutes             127.0.0.1:58516->6443/tcp   kind-control-plane
```

It'd be great if the `k9s` container could connect to the `kind` container.
